### PR TITLE
fix answer spacing

### DIFF
--- a/app/routes/polls/$id/index.tsx
+++ b/app/routes/polls/$id/index.tsx
@@ -528,21 +528,19 @@ export default function PollDetail() {
 												}{" "}
 												votes
 											</small>
-											<p>
-												{showVotedBy && isAdmin && (
-													<>
-														{getVotesFromAllUsers(
-															answer.id
-														).map((user) => (
-															<strong
-																key={user.id}
-															>
-																{user.email}{" "}
-															</strong>
-														))}
-													</>
-												)}
-											</p>
+											{showVotedBy && isAdmin && (
+												<>
+													{getVotesFromAllUsers(
+														answer.id
+													).map((user) => (
+														<strong
+															key={user.id}
+														>
+															{user.email}{" "}
+														</strong>
+													))}
+												</>
+											)}
 										</span>
 									)}
 								</li>


### PR DESCRIPTION
resolves #117 
![Screenshot 2022-12-01 at 17 18 45](https://user-images.githubusercontent.com/18416852/205106008-b247c342-f7fa-41a0-b2dd-01080f91af90.png)

Removing the p tags fixes the spacing.
Not sure what the impact is on the admin view